### PR TITLE
[이아영] 리액트 훅 4주차 과제 제출

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 - [x] usePreventLeave
 - [x] usePageLeave
 - [x] useFadeIn
-- [ ] useFullscreen
-- [ ] useNetwork
-- [ ] useNotification
-- [ ] useScroll
-- [ ] useAxios
+- [x] useFullscreen
+- [x] useNetwork
+- [x] useNotification
+- [x] useScroll
+- [x] useAxios

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@types/react-router-dom": "^5.3.3",
+        "axios": "^1.8.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.3.0"
@@ -1547,6 +1548,23 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1576,6 +1594,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/callsites": {
@@ -1624,6 +1655,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -1686,6 +1729,74 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.1",
@@ -2044,6 +2155,41 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2057,6 +2203,52 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob-parent": {
@@ -2085,6 +2277,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -2100,6 +2304,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/ignore": {
@@ -2260,6 +2503,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2282,6 +2534,27 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -2471,6 +2744,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@types/react-router-dom": "^5.3.3",
+    "axios": "^1.8.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.3.0"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,9 @@ const App = () => {
         <li>
           <Link to='/create-useNotification'>useNotification</Link>
         </li>
+        <li>
+          <Link to='/create-useAxios'>useAxios</Link>
+        </li>
       </ol>
     </>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,9 @@ const App = () => {
         <li>
           <Link to='/create-useFullscreen'>useFullscreen</Link>
         </li>
+        <li>
+          <Link to='/create-useNotification'>useNotification</Link>
+        </li>
       </ol>
     </>
   );

--- a/src/hooks/useAxios.ts
+++ b/src/hooks/useAxios.ts
@@ -1,0 +1,50 @@
+import defaultAxios, {
+  AxiosError,
+  AxiosInstance,
+  AxiosRequestConfig,
+} from 'axios';
+import { useEffect, useState } from 'react';
+
+interface AxiosState<T> {
+  loading: boolean;
+  error: AxiosError | null;
+  data: T | null;
+}
+
+type UseAxiosReturn<T> = AxiosState<T> & { refetch: () => void };
+
+export const useAxios = <T>(
+  opts: AxiosRequestConfig,
+  axiosInstance: AxiosInstance = defaultAxios
+): UseAxiosReturn<T> => {
+  //* 함수가 반환하는 데이터 타입을 제너릭으로 유연하게 설정하기
+  const [state, setState] = useState({
+    loading: true,
+    error: null,
+    data: null,
+  });
+
+  const [trigger, setTrigger] = useState(0);
+
+  const refetch = () => {
+    setState({
+      ...state,
+      loading: true,
+    });
+    setTrigger(Date.now());
+  };
+
+  useEffect(() => {
+    if (!opts.url) {
+      return;
+    }
+    axiosInstance(opts)
+      .then((data) => {
+        setState({ ...state, loading: false, data: data.data });
+      })
+      .catch((error) => {
+        setState({ ...state, loading: false, error });
+      });
+  }, [trigger]);
+  return { ...state, refetch };
+};

--- a/src/hooks/useNotification.ts
+++ b/src/hooks/useNotification.ts
@@ -1,0 +1,23 @@
+export const useNotification = (
+  title: string,
+  options?: NotificationOptions
+): (() => void) | undefined => {
+  //* Notification이 window에 없을때 반환값이 없음 즉 undefined이므로 타입에서도 넣어주어야 함
+  if (!('Notification' in window)) {
+    return;
+  }
+
+  const fireNotif = () => {
+    if (Notification.permission !== 'granted') {
+      Notification.requestPermission().then((permission) => {
+        if (permission === 'granted') {
+          new Notification(title, options);
+        }
+      });
+    } else {
+      new Notification(title, options);
+    }
+  };
+
+  return fireNotif;
+};

--- a/src/pages/02-useEffect/UseAxios.tsx
+++ b/src/pages/02-useEffect/UseAxios.tsx
@@ -1,0 +1,29 @@
+import { useAxios } from '@/hooks/useAxios';
+
+interface AccountDetailResponse {
+  accountId: number;
+  email: string;
+  nickname: string;
+  bio: string;
+}
+
+const UseAxios = () => {
+  const { loading, data, error, refetch } = useAxios<AccountDetailResponse>({
+    url: 'http://efub-seminar.p-e.kr:8080/accounts/34',
+    method: 'GET',
+  });
+
+  console.log(
+    `Loading: ${loading}\nError:${error}\nData:${JSON.stringify(data)}`
+  );
+
+  return (
+    <div>
+      <h1>{data && data.nickname}</h1>
+      <h2>{loading && 'Loading...'}</h2>
+      <button onClick={refetch}>Refetch</button>
+    </div>
+  );
+};
+
+export default UseAxios;

--- a/src/pages/02-useEffect/UseAxios.tsx
+++ b/src/pages/02-useEffect/UseAxios.tsx
@@ -9,8 +9,7 @@ interface AccountDetailResponse {
 
 const UseAxios = () => {
   const { loading, data, error, refetch } = useAxios<AccountDetailResponse>({
-    url: 'http://efub-seminar.p-e.kr:8080/accounts/34',
-    method: 'GET',
+    url: '',
   });
 
   console.log(

--- a/src/pages/02-useEffect/UseFullscreen.tsx
+++ b/src/pages/02-useEffect/UseFullscreen.tsx
@@ -1,4 +1,4 @@
-import { useFullscreen } from '@/hooks/useFullScreen';
+import { useFullscreen } from '@/hooks/useFullscreen';
 
 const UseFullscreen = () => {
   const onFulls = (isFull: boolean) => {

--- a/src/pages/02-useEffect/UseNotification.tsx
+++ b/src/pages/02-useEffect/UseNotification.tsx
@@ -1,0 +1,14 @@
+import { useNotification } from '@/hooks/useNotification';
+
+const UseNotification = () => {
+  const triggerNotif = useNotification('Cant I steal your energy?', {
+    body: "'No you can't",
+  });
+  return (
+    <div>
+      <button onClick={triggerNotif}>Hellos</button>
+    </div>
+  );
+};
+
+export default UseNotification;

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -12,6 +12,7 @@ import UseNetwork from './pages/02-useEffect/UseNetwork';
 import UseScroll from './pages/02-useEffect/UseScroll';
 import UseFullscreen from './pages/02-useEffect/UseFullscreen';
 import UseNotification from './pages/02-useEffect/UseNotification';
+import UseAxios from './pages/02-useEffect/UseAxios';
 
 const router = createBrowserRouter([
   { path: '/', element: <App /> },
@@ -27,6 +28,7 @@ const router = createBrowserRouter([
   { path: '/create-useScroll', element: <UseScroll /> },
   { path: '/create-useFullscreen', element: <UseFullscreen /> },
   { path: '/create-useNotification', element: <UseNotification /> },
+  { path: '/create-useAxios', element: <UseAxios /> },
 ]);
 
 export default router;

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -10,7 +10,8 @@ import UseBeforeLeave from './pages/02-useEffect/UseBeforeLeave';
 import UseFadeIn from './pages/02-useEffect/UseFadeIn';
 import UseNetwork from './pages/02-useEffect/UseNetwork';
 import UseScroll from './pages/02-useEffect/UseScroll';
-import UseFullscreen from './pages/02-useEffect/UseFullScreen';
+import UseFullscreen from './pages/02-useEffect/UseFullscreen';
+import UseNotification from './pages/02-useEffect/UseNotification';
 
 const router = createBrowserRouter([
   { path: '/', element: <App /> },
@@ -25,6 +26,7 @@ const router = createBrowserRouter([
   { path: '/create-useNetwork', element: <UseNetwork /> },
   { path: '/create-useScroll', element: <UseScroll /> },
   { path: '/create-useFullscreen', element: <UseFullscreen /> },
+  { path: '/create-useNotification', element: <UseNotification /> },
 ]);
 
 export default router;


### PR DESCRIPTION
# 구현 기능(수행 과제 내용)
- useNotification
- useAxios
- publish on npm (직접 수행 X)
# 과제 정리
- `useNotification`을 통해 외부 브라우저 Notification API 사용하여 웹 알림 설정 구현
- `useAxios`에서 Axios의 요청 타입 및 응답 타입을 제너릭으로 관리함
- npm 퍼블리싱 과정을 보며, 어렵지 않으면서도 실제 사용자의 사용환경을 고려하여 배포시 고려해야 할 설정( ex. 패키지 등) 들을 꼼꼼히 확인해야 함을 느낌. 
<!--과제 및 세션에 대한 내용을 요약합니다.-->
<!-- 기술블로그, 노션 링크(웹에서 공유 및 게스트 열람 가능하게 권한 변경)를 첨부하셔도 괜찮습니다.-->

# 어려웠던 점
`useAxios`에서 타입스크립트를 같이 사용하는 부분이 어려웠음. Axios 요청의 타입을 명확히 설정하기 위한 제너릭과 인터페이스를 사용했고 또 refetch의 타입을 포함하기 위해서 처음에 AxiosState 인터페이스에 `refetch : (() => void)`를 추가했는데, 이후 상태와 로직을 명확히 분리하는 것이 낫다고 판단하여 `type UseAxiosReturn<T> = AxiosState<T> & { refetch: () => void };`로 타입을 확장하여 새로운 반환 타입을 정의 
<!--생략 가능 -->
